### PR TITLE
Adds node16, nodenext and bundler TS module resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
   "exports": {
     ".": {
       "solid": "./dist/source/index.jsx",
-      "default": "./dist/esm/index.js"
+      "default": "./dist/esm/index.js",
+      "types": "./dist/types/index.d.ts"
     }
   },
   "scripts": {


### PR DESCRIPTION
For types to work when the moduleResolution is set to bundler, nodenext, or node16 in the TSConfig, types need to be added to the export. When a solid project is created with the [vite scaffolding](https://vitejs.dev/guide/#scaffolding-your-first-vite-project) it uses the bundler moduleResolution option which causes `solid-map-gl` to give errors.

More info in moduleResolution 
https://www.typescriptlang.org/tsconfig#moduleResolution
https://www.typescriptlang.org/docs/handbook/modules/reference.html#node16-nodenext